### PR TITLE
Strip podcast episode prefixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 	"sort"
 	"time"
 
@@ -57,7 +58,7 @@ func makeHandler(master *feeds.Feed) rss.ItemHandlerFunc {
 
 			if published.After(weekAgo) {
 				item := &feeds.Item{
-					Title:       items[i].Title,
+					Title:       stripPodcastEpisodePrefix(items[i].Title),
 					Link:        &feeds.Link{Href: items[i].Links[0].Href},
 					Description: items[i].Description,
 					Author:      &feeds.Author{Name: items[i].Author.Name},
@@ -81,4 +82,10 @@ func (s ByCreated) Swap(i, j int) {
 
 func (s ByCreated) Less(i, j int) bool {
 	return s[j].Created.Before(s[i].Created)
+}
+
+var podcastEpisodePrefix = regexp.MustCompile(`^\d+: `)
+
+func stripPodcastEpisodePrefix(s string) string {
+	return podcastEpisodePrefix.ReplaceAllString(s, "")
 }

--- a/rss_test.go
+++ b/rss_test.go
@@ -1,0 +1,17 @@
+package main
+
+import "testing"
+
+func TestStripPodcastEpisodePrefix(t *testing.T) {
+	for _, tt := range []struct{ in, want string }{
+		{"Better Commit Messages", "Better Commit Messages"},
+		{"10: Minisode 0.1.1", "Minisode 0.1.1"},
+		{"", ""},
+	} {
+		got := stripPodcastEpisodePrefix(tt.in)
+
+		if got != tt.want {
+			t.Errorf("stripPodcastEpisodePrefix(%q) = %q; want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
In the aggregated RSS feed provided by `rss`,
it's confusing to have podcasts
prefixed with an episode number,
so we strip them out.
