### PR TITLE
Use content source as author name

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/thoughtbot/rss",
-	"GoVersion": "go1.5",
+	"GoVersion": "go1.5.1",
 	"Packages": [
 		"./..."
 	],


### PR DESCRIPTION
Why:

* The weekly newsletter is currently hiding the author field
 because it is set to "thoughtbot" for the podcasts,
 which is confusing and redundant.
* We can better set expectations for newsletter readers about the type
 of content they are clicking on by including words "blog", "podcast",
 and "videos".

Technical details and choices:

* Simplecast sets "author" to "thoughtbot" for all the podcasts.
 This needs to stay that way because of how iTunes uses that field
 and indexes all our content as a single author.
* We could use the individual people's names for the blog posts,
 but I was thinking consistency is better.

Separate commit:

* Upgrade to Go version 1.5.1.