### PR TITLE
Increase speed of fetching RSS feeds

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -18,7 +18,7 @@ if [ -z "$CI" ]; then
   fi
 
   if heroku join --app thoughtbot-rss > /dev/null; then
-    git remote add production git@heroku.com:thoughtbot-rss.git > /dev/null
+    git remote add production git@heroku.com:thoughtbot-rss.git 2> /dev/null
   else
     printf 'Ask for access to the "thoughtbot-rss" Heroku app\n'
   fi

--- a/circle.yml
+++ b/circle.yml
@@ -14,3 +14,4 @@ test:
     - bin/vet
   override:
     - godep go test ./...
+    - godep go test -bench=.

--- a/main.go
+++ b/main.go
@@ -29,14 +29,18 @@ func rssHandler(rw http.ResponseWriter, r *http.Request) {
 		Created:     time.Now(),
 	}
 
-	for _, feed := range sourceFeeds {
-		fetch(feed, master)
-	}
+	fetchFeeds(master)
 
 	sort.Sort(byCreated(master.Items))
 
 	result, _ := master.ToAtom()
 	fmt.Fprintln(rw, result)
+}
+
+func fetchFeeds(master *feeds.Feed) {
+	for _, feed := range sourceFeeds {
+		fetch(feed, master)
+	}
 }
 
 func fetch(feed sourceFeed, master *feeds.Feed) {

--- a/main.go
+++ b/main.go
@@ -40,9 +40,9 @@ func rssHandler(rw http.ResponseWriter, r *http.Request) {
 
 func fetchFeeds(master *feeds.Feed) {
 	var wg sync.WaitGroup
-	wg.Add(len(sourceFeeds))
 	for _, feed := range sourceFeeds {
 		go func(feed sourceFeed) {
+			wg.Add(1)
 			defer wg.Done()
 			fetch(feed, master)
 		}(feed)

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"regexp"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/gorilla/feeds"
@@ -38,9 +39,15 @@ func rssHandler(rw http.ResponseWriter, r *http.Request) {
 }
 
 func fetchFeeds(master *feeds.Feed) {
+	var wg sync.WaitGroup
+	wg.Add(len(sourceFeeds))
 	for _, feed := range sourceFeeds {
-		fetch(feed, master)
+		go func(feed sourceFeed) {
+			defer wg.Done()
+			fetch(feed, master)
+		}(feed)
 	}
+	wg.Wait()
 }
 
 func fetch(feed sourceFeed, master *feeds.Feed) {

--- a/rss_test.go
+++ b/rss_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/gorilla/feeds"
+)
 
 func TestStripPodcastEpisodePrefix(t *testing.T) {
 	for _, tt := range []struct{ in, want string }{
@@ -13,5 +17,11 @@ func TestStripPodcastEpisodePrefix(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("stripPodcastEpisodePrefix(%q) = %q; want %q", tt.in, got, tt.want)
 		}
+	}
+}
+
+func BenchmarkFetchFeeds(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		fetchFeeds(&feeds.Feed{})
 	}
 }


### PR DESCRIPTION
Benchmarks for before and after the code change are available in individual
commits. This change results in an average time of 802604696.33ns for warm
requests, decreased from 1806248432ns. This is a 55.6% improvement.
