### PR TITLE
Add HTTP timeout to RSS fetch

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,11 @@ func rssHandler(rw http.ResponseWriter, r *http.Request) {
 
 func fetch(feed sourceFeed, master *feeds.Feed) {
 	fetcher := rss.New(5, true, chanHandler, makeHandler(master, feed.name))
-	fetcher.Fetch(feed.uri, nil)
+	client := &http.Client{
+		Timeout: time.Second,
+	}
+
+	fetcher.FetchClient(feed.uri, client, nil)
 }
 
 func chanHandler(feed *rss.Feed, newchannels []*rss.Channel) {


### PR DESCRIPTION
Cause:

* Our podcast provider, Simplecast.fm, is hosted on Linode.
* Linode is undergoing a DDoS attack.
* Our podcast RSS feeds are not available.

Goal:

* This chains of events should not cause rss.thoughtbot.com to time out.