### PR TITLE
Add open source releases to our feed

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,12 @@ var sourceFeeds = []sourceFeed{
 	{uri: "http://simplecast.fm/podcasts/282/rss", name: "The Bike Shed podcast"},
 	{uri: "http://simplecast.fm/podcasts/1088/rss", name: "Tentative podcast"},
 	{uri: "https://upcase.com/the-weekly-iteration.rss", name: "The Weekly Iteration videos"},
+	{uri: "https://github.com/thoughtbot/bourbon/releases.atom", name: "bourbon release"},
+	{uri: "https://github.com/thoughtbot/clearance/releases.atom", name: "clearance release"},
+	{uri: "https://github.com/thoughtbot/factory_girl/releases.atom", name: "factory_girl release"},
+	{uri: "https://github.com/thoughtbot/high_voltage/releases.atom", name: "high_voltage release"},
+	{uri: "https://github.com/thoughtbot/paperclip/releases.atom", name: "paperclip release"},
+	{uri: "https://github.com/thoughtbot/suspenders/releases.atom", name: "suspenders release"},
 }
 
 func main() {


### PR DESCRIPTION
Right now, content looks like:

```
<entry>
<title>v1.38.0</title>
<updated>2016-04-15T19:47:11Z</updated>
<id>
tag:,2016-04-15:/thoughtbot/suspenders/releases/tag/v1.38.0
</id>
<content type="html"/>
<link href="/thoughtbot/suspenders/releases/tag/v1.38.0"/>
<author>
<name>suspenders releases</name>
</author>
</entry>
```

To do:

- [ ] Link to full GitHub URL
- [ ] Show release notes
- [ ] What other open source projects should we list?