### PR TITLE
Redirect HTTP to HTTPS

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,17 @@ func main() {
 }
 
 func rssHandler(sourceFeeds []sourceFeed) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Host == "rss.thoughtbot.com" && req.URL.Scheme != "https" {
+			http.Redirect(
+				w,
+				req,
+				"https://rss.thoughtbot.com/",
+				http.StatusMovedPermanently,
+			)
+			return
+		}
+
 		master := &feeds.Feed{
 			Title:       "thoughtbot",
 			Link:        &feeds.Link{Href: "https://rss.thoughtbot.com"},


### PR DESCRIPTION
Automated Certificate Management is now turned on for this Heroku app.
https://blog.heroku.com/announcing-automated-certificate-management

We always get HTTP on our app, though.
TLS is terminated by the Heroku proxy.

http://rss.thoughtbot.com/ and https://rss.thoughtbot.com/
both currently work.

So, let's redirect all HTTP traffic to HTTPS.
This can't be done at the DNS level:
https://support.dnsimple.com/articles/redirect-heroku/#redirect-http2https

It must be done at the application level.

Hardcode the host in the conditional branch to make local testing easy.