### PR TITLE
Use itunes:subtitle as podcast episode description

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func stripPodcastEpisodePrefix(s string) string {
 
 func getDescription(item *rss.Item) string {
 	if ext, ok := item.Extensions["http://www.itunes.com/dtds/podcast-1.0.dtd"]; ok {
-		return ext["summary"][0].Value
+		return ext["subtitle"][0].Value
 	}
 
 	return item.Description

--- a/rss_test.go
+++ b/rss_test.go
@@ -33,7 +33,7 @@ func TestGetDescription(t *testing.T) {
 	want = "from itunes"
 	item = &rss.Item{Extensions: map[string]map[string][]rss.Extension{
 		"http://www.itunes.com/dtds/podcast-1.0.dtd": map[string][]rss.Extension{
-			"summary": []rss.Extension{
+			"subtitle": []rss.Extension{
 				{
 					Value: want,
 				},


### PR DESCRIPTION
Resolves: https://trello.com/c/gr0d0YNA

Currently, the Giant Robots newsletter includes show notes on every podcast episode, which can include advertisements and 5-10 links. We received feedback from our audience that these links are not helpful, and have decided to remove them.

The weekly Giant Robots newsletter is sent from the Giant Robots RSS Mailchimp campaign and uses rss.thoughtbot.com as the source of some of its content. The feed is a consolidation of various other feeds, and uses an attribute that includes the episode's show notes as the description. As a result, the episode show notes are also included in the newsletter.

There was existing work done in August 2019 (not yet deployed) that modified the RSS feed to use the `itunes:summary` attribute as the description for podcast episodes. This attribute, however, still includes the episode's show notes. Using the `itunes:subtitle` attribute instead gives a description without the episode's show notes.